### PR TITLE
Replace deprecated base64 api in Encryption

### DIFF
--- a/arkenv/src/main/kotlin/com/apurebase/arkenv/feature/Encryption.kt
+++ b/arkenv/src/main/kotlin/com/apurebase/arkenv/feature/Encryption.kt
@@ -1,8 +1,8 @@
 package com.apurebase.arkenv.feature
 
 import com.apurebase.arkenv.Arkenv
+import java.util.*
 import javax.crypto.Cipher
-import javax.xml.bind.DatatypeConverter
 
 /**
  * Supports decryption of encrypted values during the processing phase.
@@ -29,8 +29,8 @@ class Encryption(private val cipher: Cipher) : ProcessorFeature {
         }
     }
 
-    private fun Cipher.decrypt(input: String): String = DatatypeConverter
-        .parseHexBinary(input)
+    private fun Cipher.decrypt(input: String): String = Base64.getDecoder()
+        .decode(input)
         .let(::doFinal)
         .let { String(it) }
 }

--- a/arkenv/src/test/kotlin/com/apurebase/arkenv/feature/EncryptionTest.kt
+++ b/arkenv/src/test/kotlin/com/apurebase/arkenv/feature/EncryptionTest.kt
@@ -10,8 +10,8 @@ import strikt.assertions.isEqualTo
 import java.security.Key
 import java.security.KeyPair
 import java.security.KeyPairGenerator
+import java.util.*
 import javax.crypto.Cipher
-import javax.xml.bind.DatatypeConverter
 
 internal class EncryptionTest {
 
@@ -50,6 +50,6 @@ internal class EncryptionTest {
 
         fun encrypt(input: String): String = encryptCipher
             .doFinal(input.toByteArray())
-            .let { DatatypeConverter.printHexBinary(it) }
+            .let(Base64.getEncoder()::encodeToString)
     }
 }


### PR DESCRIPTION
Closes #1 

We still need to integrate ci cd either from gitlab or with github actions. 