### PR TITLE
#6 provide mappings for primitive arrays

### DIFF
--- a/arkenv/src/main/kotlin/com/apurebase/arkenv/Arkenv.kt
+++ b/arkenv/src/main/kotlin/com/apurebase/arkenv/Arkenv.kt
@@ -67,7 +67,7 @@ abstract class Arkenv(
                 .append(doubleIndent)
                 .append(delegate.property.name)
                 .append(doubleIndent)
-                .append(delegate.getValue(this, delegate.property))
+                .append(delegate.getValue(this@Arkenv, delegate.property))
                 .appendln()
         }
     }.toString()

--- a/arkenv/src/main/kotlin/com/apurebase/arkenv/ArkenvBuilder.kt
+++ b/arkenv/src/main/kotlin/com/apurebase/arkenv/ArkenvBuilder.kt
@@ -47,9 +47,7 @@ class ArkenvBuilder {
      * Uninstalls the [feature] from [Arkenv] if installed.
      */
     fun uninstall(feature: ArkenvFeature) {
-        features.removeIf {
-            feature.getKeyValPair().first == it.getKeyValPair().first
-        }
+        features.removeIf { feature.key == it.key }
     }
 
     init {

--- a/arkenv/src/main/kotlin/com/apurebase/arkenv/ArkenvDelegateLoader.kt
+++ b/arkenv/src/main/kotlin/com/apurebase/arkenv/ArkenvDelegateLoader.kt
@@ -1,40 +1,22 @@
 package com.apurebase.arkenv
 
 import kotlin.properties.ReadOnlyProperty
-import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 
 class ArkenvDelegateLoader<T : Any>(
     private val argument: Argument<T>,
-    private val kClass: KClass<T>,
     private val arkenv: Arkenv
 ) {
-    operator fun provideDelegate(thisRef: Any?, prop: KProperty<*>): ReadOnlyProperty<Any?, T> = createDelegate(prop)
-
-    private fun createDelegate(prop: KProperty<*>): ArgumentDelegate<T> = with(argument) {
-        names = (if (names.isEmpty()) listOf("--${prop.name.toSnakeCase()}") else names).let(::processNames)
-
-        return ArgumentDelegate(
-            arkenv,
-            argument,
-            prop,
-            kClass == Boolean::class,
-            mapping ?: getMapping(prop)
-        ).also { arkenv.delegates.add(it) }
+    operator fun provideDelegate(thisRef: Arkenv, prop: KProperty<*>): ReadOnlyProperty<Arkenv, T> {
+        argument.names = getNames(argument.names, prop.name)
+        return ArgumentDelegate(argument, prop)
+            .also { arkenv.delegates.add(it) }
     }
 
-    private fun processNames(names: List<String>) = names.map {
-        if (!it.startsWith("-")) "--$it".mapRelaxed()
-        else it.mapRelaxed()
-    }
-
-    @Suppress("UNCHECKED_CAST", "IMPLICIT_CAST_TO_ANY")
-    private fun getMapping(prop: KProperty<*>): (String) -> T = { value ->
-        when (kClass) {
-            Int::class -> value.toIntOrNull()
-            Long::class -> value.toLongOrNull()
-            String::class -> value
-            else -> throw IllegalArgumentException("${prop.name} ($kClass) is not supported")
-        } as T
-    }
+    private fun getNames(names: List<String>, propName: String) =
+        names.ifEmpty { listOf("--${propName.toSnakeCase()}") }
+            .map {
+                if (!it.startsWith("-")) "--$it".mapRelaxed()
+                else it.mapRelaxed()
+            }
 }

--- a/arkenv/src/main/kotlin/com/apurebase/arkenv/ArkenvUtil.kt
+++ b/arkenv/src/main/kotlin/com/apurebase/arkenv/ArkenvUtil.kt
@@ -1,6 +1,7 @@
 package com.apurebase.arkenv
 
 import com.apurebase.arkenv.feature.ArkenvFeature
+import kotlin.reflect.KClass
 import kotlin.reflect.jvm.jvmName
 
 /**
@@ -23,14 +24,14 @@ fun <T : Arkenv> T.parse(args: Array<String>) = apply { parseArguments(args) }
  * but the last supplied argument
  * @param configuration optional configuration of the argument's properties
  */
-inline fun <reified T : Any> Arkenv.argument(
+inline fun <T : Any> Arkenv.argument(
     names: List<String>,
     isMainArg: Boolean = false,
     configuration: Argument<T>.() -> Unit = {}
 ): ArkenvDelegateLoader<T> {
     val argument = Argument<T>(names).apply(configuration)
     argument.isMainArg = isMainArg
-    return ArkenvDelegateLoader(argument, T::class, this)
+    return ArkenvDelegateLoader(argument, this)
 }
 
 /**
@@ -38,7 +39,7 @@ inline fun <reified T : Any> Arkenv.argument(
  * @param names the names that the argument can be called with
  * @param configuration optional configuration of the argument's properties
  */
-inline fun <reified T : Any> Arkenv.argument(
+inline fun <T : Any> Arkenv.argument(
     vararg names: String,
     configuration: Argument<T>.() -> Unit = {}
 ): ArkenvDelegateLoader<T> = argument(names.toList(), false, configuration)
@@ -49,10 +50,10 @@ inline fun <reified T : Any> Arkenv.argument(
  * The main argument can't be passed through environment variables.
  * @param block the configuration that will be applied to the Argument
  */
-inline fun <reified T : Any> Arkenv.mainArgument(block: Argument<T>.() -> Unit = {}): ArkenvDelegateLoader<T> =
+inline fun <T : Any> Arkenv.mainArgument(block: Argument<T>.() -> Unit = {}): ArkenvDelegateLoader<T> =
     argument(listOf(), true, block)
 
-internal fun ArkenvFeature.getKeyValPair() = this::class.jvmName to this
+internal val ArkenvFeature.key get() = this::class.jvmName
 
 internal fun Arkenv.isHelp(): Boolean = when {
     argList.isEmpty() && !delegates.first { it.argument.isHelp }.isSet -> false
@@ -78,3 +79,29 @@ fun Arkenv.putAll(from: Map<out String, String>) = from.forEach { (k, v) -> set(
  */
 operator fun Arkenv.get(key: String): String =
     getOrNull(key) ?: throw IllegalArgumentException("Arkenv does not contain a value for key '$key'")
+
+/**
+ * Maps the input [value] to an instance of [T] using [clazz] as a reference.
+ * @throws IllegalArgumentException if the mapping is not supported or didn't succeed
+ */
+@Suppress("UNCHECKED_CAST", "IMPLICIT_CAST_TO_ANY", "ComplexMethod", "LongMethod", "TooGenericExceptionCaught")
+internal fun <T> mapDefault(key: String, value: String, clazz: KClass<*>): T = try {
+    with(value) {
+        when (clazz) {
+            Int::class -> toIntOrNull()
+            Long::class -> toLongOrNull()
+            String::class -> value
+            IntArray::class -> split().map(String::toInt).toIntArray()
+            ShortArray::class -> split().map(String::toShort).toShortArray()
+            CharArray::class -> toCharArray()
+            LongArray::class -> split().map(String::toLong).toLongArray()
+            FloatArray::class -> split().map(String::toFloat).toFloatArray()
+            DoubleArray::class -> split().map(String::toDouble).toDoubleArray()
+            BooleanArray::class -> split().map(String::toBoolean).toBooleanArray()
+            ByteArray::class -> split().map(String::toByte).toByteArray()
+            else -> throw IllegalArgumentException("$key ($clazz) is not supported. Define a custom mapping.")
+        } as T
+    }
+} catch (ex: RuntimeException) {
+    throw IllegalArgumentException("Could not parse $key - $value as $clazz", ex)
+}

--- a/arkenv/src/main/kotlin/com/apurebase/arkenv/ArkenvUtil.kt
+++ b/arkenv/src/main/kotlin/com/apurebase/arkenv/ArkenvUtil.kt
@@ -92,6 +92,7 @@ internal fun <T> mapDefault(key: String, value: String, clazz: KClass<*>): T = t
             Long::class -> toLongOrNull()
             String::class -> value
             Char::class -> firstOrNull()
+            List::class, Collection::class -> split()
             IntArray::class -> split().map(String::toInt).toIntArray()
             ShortArray::class -> split().map(String::toShort).toShortArray()
             CharArray::class -> toCharArray()
@@ -100,9 +101,9 @@ internal fun <T> mapDefault(key: String, value: String, clazz: KClass<*>): T = t
             DoubleArray::class -> split().map(String::toDouble).toDoubleArray()
             BooleanArray::class -> split().map(String::toBoolean).toBooleanArray()
             ByteArray::class -> split().map(String::toByte).toByteArray()
-            else -> throw IllegalArgumentException("$key ($clazz) is not supported. Define a custom mapping.")
+            else -> throw UnsupportedMappingException(key, clazz)
         } as T
     }
 } catch (ex: RuntimeException) {
-    throw IllegalArgumentException("Could not parse $key - $value as $clazz", ex)
+    throw MappingException(key, value, clazz, ex)
 }

--- a/arkenv/src/main/kotlin/com/apurebase/arkenv/ArkenvUtil.kt
+++ b/arkenv/src/main/kotlin/com/apurebase/arkenv/ArkenvUtil.kt
@@ -91,6 +91,7 @@ internal fun <T> mapDefault(key: String, value: String, clazz: KClass<*>): T = t
             Int::class -> toIntOrNull()
             Long::class -> toLongOrNull()
             String::class -> value
+            Char::class -> firstOrNull()
             IntArray::class -> split().map(String::toInt).toIntArray()
             ShortArray::class -> split().map(String::toShort).toShortArray()
             CharArray::class -> toCharArray()

--- a/arkenv/src/main/kotlin/com/apurebase/arkenv/StringUtils.kt
+++ b/arkenv/src/main/kotlin/com/apurebase/arkenv/StringUtils.kt
@@ -34,5 +34,7 @@ internal fun String.mapRelaxed(): String =
     if (isAdvancedName()) "--" + toSnakeCase()
     else this
 
+internal fun String.split() = split(',')
+
 internal const val DEPRECATED_GENERAL = "Will be removed in future major version"
 internal const val DEPRECATED_USE_FEATURE = "$DEPRECATED_GENERAL. Use Features instead."

--- a/arkenv/src/main/kotlin/com/apurebase/arkenv/ValidationException.kt
+++ b/arkenv/src/main/kotlin/com/apurebase/arkenv/ValidationException.kt
@@ -1,10 +1,27 @@
 package com.apurebase.arkenv
 
+import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
+
+internal open class ArkenvException(message: String, cause: Exception? = null) : RuntimeException(message, cause)
 
 /**
  * Unchecked exception thrown when validation of an [Argument] was unsuccessful.
  */
-internal class ValidationException(property: KProperty<*>, value: Any?, message: String) : IllegalArgumentException(
+internal class ValidationException(property: KProperty<*>, value: Any?, message: String) : ArkenvException(
     "Argument ${property.name} with value '$value' did not pass validation: '$message'"
+)
+
+/**
+ * Unchecked exception thrown when no supported mapping exists for the given class.
+ */
+internal class UnsupportedMappingException(key: String, clazz: KClass<*>) : ArkenvException(
+    "Property '$key' of type '$clazz' is not supported. Define a custom mapping."
+)
+
+/**
+ * Unchecked exception thrown when mapping was unsuccessful.
+ */
+internal class MappingException(key: String, value: String, clazz: KClass<*>, cause: Exception) : ArkenvException(
+    "Could not parse property '$key' with value '$value' as class '$clazz'", cause
 )

--- a/arkenv/src/main/kotlin/com/apurebase/arkenv/ValidationException.kt
+++ b/arkenv/src/main/kotlin/com/apurebase/arkenv/ValidationException.kt
@@ -5,6 +5,6 @@ import kotlin.reflect.KProperty
 /**
  * Unchecked exception thrown when validation of an [Argument] was unsuccessful.
  */
-class ValidationException(property: KProperty<*>, value: Any?, message: String) : IllegalArgumentException(
+internal class ValidationException(property: KProperty<*>, value: Any?, message: String) : IllegalArgumentException(
     "Argument ${property.name} with value '$value' did not pass validation: '$message'"
 )

--- a/arkenv/src/main/kotlin/com/apurebase/arkenv/feature/ProfileFeature.kt
+++ b/arkenv/src/main/kotlin/com/apurebase/arkenv/feature/ProfileFeature.kt
@@ -28,7 +28,6 @@ class ProfileFeature(
 
     internal val profiles: List<String> by argument(name) {
         defaultValue = ::emptyList
-        mapping = { it.split(',') }
     }
 
     private val prefix: String by argument("--arkenv-profile-prefix") {
@@ -36,7 +35,6 @@ class ProfileFeature(
     }
 
     private val location: Collection<String> by argument("--arkenv-profile-location") {
-        mapping = { it.split(",").map(String::trim) }
         defaultValue = { locations }
     }
 

--- a/arkenv/src/main/kotlin/com/apurebase/arkenv/feature/PropertyFeature.kt
+++ b/arkenv/src/main/kotlin/com/apurebase/arkenv/feature/PropertyFeature.kt
@@ -17,11 +17,9 @@ open class PropertyFeature(
 ) : ArkenvFeature, Arkenv("PropertyFeature") {
 
     protected open val extensions = listOf("properties")
-    private val defaultLocations = listOf("", "config/")
-    private val locations: Collection<String> by argument("--arkenv-property-location") {
-        val combined = locations + defaultLocations
-        mapping = { it.split(',') + combined }
-        defaultValue = { combined }
+    private val defaultLocations = locations + listOf("", "config/")
+    private val extraLocations: List<String> by argument("--arkenv-property-location") {
+        defaultValue = ::emptyList
     }
 
     override fun onLoad(arkenv: Arkenv) {
@@ -42,7 +40,7 @@ open class PropertyFeature(
     protected open fun parse(stream: InputStream): Map<String, String> = parseProperties(stream)
 
     private fun getStream(name: String): InputStream? {
-        locations
+        (extraLocations + defaultLocations)
             .map { fixLocation(it) + name }
             .forEach {
                 val stream = getFileStream(it) ?: getResourceStream(it)
@@ -51,7 +49,7 @@ open class PropertyFeature(
         return null
     }
 
-    private fun fixLocation(location: String) = // TODO test this
+    private fun fixLocation(location: String) =
         if (location.isNotBlank() && !location.endsWith('/')) "$location/"
         else location
 

--- a/arkenv/src/test/kotlin/com/apurebase/arkenv/MappingTests.kt
+++ b/arkenv/src/test/kotlin/com/apurebase/arkenv/MappingTests.kt
@@ -9,6 +9,14 @@ import strikt.assertions.isEqualTo
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 internal class MappingTests {
 
+    @Test fun `char should map`() {
+        object : Arkenv() {
+            val char: Char by argument()
+        }.parse("CHAR", "OnlyTheFirstChar").char.expectThat {
+            isEqualTo('O')
+        }
+    }
+
     @Test fun `IntArray should map`() {
         object : Arkenv() {
             val array: IntArray by argument()

--- a/arkenv/src/test/kotlin/com/apurebase/arkenv/MappingTests.kt
+++ b/arkenv/src/test/kotlin/com/apurebase/arkenv/MappingTests.kt
@@ -1,0 +1,81 @@
+package com.apurebase.arkenv
+
+import com.apurebase.arkenv.test.expectThat
+import com.apurebase.arkenv.test.parse
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import strikt.assertions.isEqualTo
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class MappingTests {
+
+    @Test fun `IntArray should map`() {
+        object : Arkenv() {
+            val array: IntArray by argument()
+        }.parse(argName, numericInput).array.expectThat {
+            isEqualTo(numericOutput.toIntArray())
+        }
+    }
+
+    @Test fun `CharArray should map`() {
+        object : Arkenv() {
+            val array: CharArray by argument()
+        }.parse(argName, "abc").array.expectThat {
+            isEqualTo(listOf('a', 'b', 'c').toCharArray())
+        }
+    }
+
+    @Test fun `ShortArray should map`() {
+        object : Arkenv() {
+            val array: ShortArray by argument()
+        }.parse(argName, numericInput).array.expectThat {
+            isEqualTo(numericOutput.map(Int::toShort).toShortArray())
+        }
+    }
+
+    @Test fun `LongArray should map`() {
+        object : Arkenv() {
+            val array: LongArray by argument()
+        }.parse(argName, numericInput).array.expectThat {
+            isEqualTo(numericOutput.map(Int::toLong).toLongArray())
+        }
+    }
+
+    @Test fun `FloatArray should map`() {
+        object : Arkenv() {
+            val array: FloatArray by argument()
+        }.parse(argName, floatingPointInput).array.expectThat {
+            isEqualTo(floatingPointOutput.map(Double::toFloat).toFloatArray())
+        }
+    }
+
+    @Test fun `DoubleArray should map`() {
+        object : Arkenv() {
+            val array: DoubleArray by argument()
+        }.parse(argName, floatingPointInput).array.expectThat {
+            isEqualTo(floatingPointOutput.toDoubleArray())
+        }
+    }
+
+    @Test fun `BooleanArray should map`() {
+        object : Arkenv() {
+            val array: BooleanArray by argument()
+        }.parse(argName, "True,False,true").array.expectThat {
+            isEqualTo(listOf(true, false, true).toBooleanArray())
+        }
+    }
+
+    @Test fun `ByteArray should map`() {
+        object : Arkenv() {
+            val array: ByteArray by argument()
+        }.parse("--$argName", "-1,2,3").array.expectThat {
+            isEqualTo(listOf(-1, 2, 3).map(Int::toByte).toByteArray())
+        }
+    }
+
+    private val floatingPointInput = "1.1,29.92,-387.9999"
+    private val floatingPointOutput = listOf(1.1, 29.92, -387.9999)
+    private val numericInput = "1,-29,387"
+    private val numericOutput = listOf(1, -29, 387)
+    private val argName = "ARRAY"
+}

--- a/arkenv/src/test/kotlin/com/apurebase/arkenv/MappingTests.kt
+++ b/arkenv/src/test/kotlin/com/apurebase/arkenv/MappingTests.kt
@@ -9,6 +9,18 @@ import strikt.assertions.isEqualTo
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 internal class MappingTests {
 
+    @Test fun `list should map to List of String`() {
+        val input = "by,default"
+        val output = listOf("by", "default")
+        object: Arkenv() {
+            val list: List<String> by argument()
+            val collection: Collection<String> by argument()
+        }.parse("LIST", input, "COLLECTION", input).expectThat {
+            get { list }.isEqualTo(output)
+            get { collection }.isEqualTo(output)
+        }
+    }
+
     @Test fun `char should map`() {
         object : Arkenv() {
             val char: Char by argument()

--- a/arkenv/src/test/kotlin/com/apurebase/arkenv/test/TestUtil.kt
+++ b/arkenv/src/test/kotlin/com/apurebase/arkenv/test/TestUtil.kt
@@ -10,6 +10,6 @@ fun getTestResourcePath(name: String): String = File("src/test/resources/$name")
 
 fun <T : Arkenv> T.parse(vararg arguments: String) = apply { parseArguments(arguments) }
 
-fun getTestResource(name: String) = MockSystem::class.java.classLoader.getResource(name).readText()
+fun getTestResource(name: String) = MockSystem::class.java.classLoader.getResource(name)!!.readText()
 
 const val DEPRECATED = "Property files are no longer required, can be null."

--- a/docs/features/mapping.md
+++ b/docs/features/mapping.md
@@ -1,0 +1,32 @@
+---
+layout: default
+title: Mapping
+parent: Features
+nav_order: 13
+---
+
+# Mapping
+
+The following mappings are supported by default:
+
+```kotlin
+object Ark : Arkenv() {
+    val int:            Int by argument()
+    val long:           Long by argument()
+    val string:         String by argument()
+    val char:           Char by argument()
+    val intArray:       IntArray by argument()
+    val shortArray:     ShortArray by argument()
+    val charArray:      CharArray by argument()
+    val longArray:      LongArray by argument()
+    val floatArray:     FloatArray by argument()
+    val doubleArray:    DoubleArray by argument()
+    val booleanArray:   BooleanArray by argument()
+    val byteArray:      ByteArray by argument()
+}
+```
+
+All array types can be defined as a comma-separated string. 
+The only exception being `CharArray`, which simply takes each input 
+character as a single array item.
+

--- a/docs/features/mapping.md
+++ b/docs/features/mapping.md
@@ -11,22 +11,28 @@ The following mappings are supported by default:
 
 ```kotlin
 object Ark : Arkenv() {
-    val int:            Int by argument()
-    val long:           Long by argument()
-    val string:         String by argument()
-    val char:           Char by argument()
-    val intArray:       IntArray by argument()
-    val shortArray:     ShortArray by argument()
-    val charArray:      CharArray by argument()
-    val longArray:      LongArray by argument()
-    val floatArray:     FloatArray by argument()
-    val doubleArray:    DoubleArray by argument()
-    val booleanArray:   BooleanArray by argument()
-    val byteArray:      ByteArray by argument()
+    val int:                Int by argument()
+    val long:               Long by argument()
+    val string:             String by argument()
+    val char:               Char by argument()
+    val intArray:           IntArray by argument()
+    val shortArray:         ShortArray by argument()
+    val charArray:          CharArray by argument()
+    val longArray:          LongArray by argument()
+    val floatArray:         FloatArray by argument()
+    val doubleArray:        DoubleArray by argument()
+    val booleanArray:       BooleanArray by argument()
+    val byteArray:          ByteArray by argument()
+    
+    val stringList:         List<String> by argument()
+    val stringCollection:   Collection<String> by argument() 
 }
 ```
 
-All array types can be defined as a comma-separated string. 
+All primitive array types can be defined as a comma-separated string. 
 The only exception being `CharArray`, which simply takes each input 
 character as a single array item.
+
+For `List` and `Collection` the type parameter is assumed to be `String`
+and will only work in this case.
 


### PR DESCRIPTION
Closes #6 

Provide default mappings for primitive arrays. 

_Also includes fix for #1 as code doesn't compile on java 11 otherwise._ 