### PR TITLE
Expose profiles extension property and active

### DIFF
--- a/arkenv/src/main/kotlin/com/apurebase/arkenv/ArkenvExceptions.kt
+++ b/arkenv/src/main/kotlin/com/apurebase/arkenv/ArkenvExceptions.kt
@@ -32,3 +32,10 @@ internal class MappingException(key: String, value: String, clazz: KClass<*>, ca
 internal class MissingArgumentException(name: String, info: String): ArkenvException(
     "No value passed for property $name ($info)"
 )
+
+/**
+ * Unchecked exception thrown when the requested feature could not be found.
+ */
+internal class FeatureNotFoundException(featureName: String?) : ArkenvException(
+    "Feature $featureName could not be found. Make sure it was installed correctly."
+)

--- a/arkenv/src/main/kotlin/com/apurebase/arkenv/ArkenvUtil.kt
+++ b/arkenv/src/main/kotlin/com/apurebase/arkenv/ArkenvUtil.kt
@@ -64,6 +64,9 @@ internal inline fun <reified T : ArkenvFeature> Arkenv.findFeature(): T? {
     return configuration.features.find { it is T } as T?
 }
 
+internal inline fun <reified T : ArkenvFeature> Arkenv.getFeature(): T =
+    findFeature() ?: throw FeatureNotFoundException(T::class.simpleName)
+
 /**
  * Inserts all key-value pairs in [from] to [Arkenv], overwriting already existing keys.
  * Applies all [ProcessorFeature]s to the value.

--- a/arkenv/src/main/kotlin/com/apurebase/arkenv/feature/ProfileFeature.kt
+++ b/arkenv/src/main/kotlin/com/apurebase/arkenv/feature/ProfileFeature.kt
@@ -1,9 +1,6 @@
 package com.apurebase.arkenv.feature
 
-import com.apurebase.arkenv.Arkenv
-import com.apurebase.arkenv.ArkenvBuilder
-import com.apurebase.arkenv.argument
-import com.apurebase.arkenv.parse
+import com.apurebase.arkenv.*
 
 /**
  * Feature for loading profile-based configuration.
@@ -25,7 +22,7 @@ class ProfileFeature(
         this.parsers.addAll(parsers)
     }
 
-    internal val profiles: List<String> by argument("--arkenv-profile") {
+    val active: List<String> by argument("--arkenv-profile") {
         defaultValue = ::emptyList
     }
 
@@ -40,7 +37,7 @@ class ProfileFeature(
     override fun onLoad(arkenv: Arkenv) {
         parse(arkenv.argList.toTypedArray())
         load(arkenv, null)
-        profiles.forEach { load(arkenv, it) }
+        active.forEach { load(arkenv, it) }
     }
 
     private fun load(arkenv: Arkenv, file: String?) = parsers
@@ -53,3 +50,5 @@ class ProfileFeature(
 }
 
 typealias PropertyParser = (String, Collection<String>) -> PropertyFeature
+
+val Arkenv.profiles get() = getFeature<ProfileFeature>()

--- a/arkenv/src/main/kotlin/com/apurebase/arkenv/feature/http/HttpFeature.kt
+++ b/arkenv/src/main/kotlin/com/apurebase/arkenv/feature/http/HttpFeature.kt
@@ -31,9 +31,9 @@ class HttpFeature(
     override fun onLoad(arkenv: Arkenv) {
         val label = arkenv.getOrNull("ARKENV_LABEL")
         val profileFeature = arkenv.findFeature<ProfileFeature>()
-        val profile = profileFeature?.profiles?.joinToString()
+        val activeProfiles = profileFeature?.active?.joinToString()
         httpClient
-            .resolveUrls(rootUrl, arkenv.programName, profile, label)
+            .resolveUrls(rootUrl, arkenv.programName, activeProfiles, label)
             .map(::parse)
             .reduce { acc, map -> acc + map }
             .let(arkenv::putAll)

--- a/arkenv/src/test/kotlin/com/apurebase/arkenv/feature/ProfileFeatureTest.kt
+++ b/arkenv/src/test/kotlin/com/apurebase/arkenv/feature/ProfileFeatureTest.kt
@@ -72,6 +72,12 @@ open class ProfileFeatureTest {
         }
     }
 
+    @Test fun `access profiles`() {
+        Ark().parse(arkenvProfile, "prod,dev").expectThat {
+            get { profiles.active }.isEqualTo(listOf("prod", "dev"))
+        }
+    }
+
     protected val arkenvProfile = "ARKENV_PROFILE"
     private val prodPort = 443
     private val devPort = 5000


### PR DESCRIPTION
Closes #17 

Active profiles can now be retrieved via 
```kotlin
Arkenv.profiles.active
```