### PR TITLE
Refactor features extending Arkenv

### DIFF
--- a/arkenv-yaml/src/main/kotlin/com/apurebase/arkenv/feature/YamlFeature.kt
+++ b/arkenv-yaml/src/main/kotlin/com/apurebase/arkenv/feature/YamlFeature.kt
@@ -19,19 +19,21 @@ class YamlFeature(
 
     override val extensions: List<String> = listOf("yml", "yaml")
 
+    private val map = mutableMapOf<String, String>()
+
     override fun parse(stream: InputStream): Map<String, String> {
         Yaml().load<Map<String, Any?>>(stream)?.map { (key, value) -> parse(key, value) }
-        return getAll()
+        return map
     }
 
-    override fun finally(arkenv: Arkenv) = clear()
+    override fun finally(arkenv: Arkenv) = map.clear()
 
     @Suppress("UNCHECKED_CAST")
     private fun parse(key: String, value: Any?) {
         when (value) {
             is Map<*, *> -> (value as? Map<String, Any?>)?.forEach { (k, v) -> parse("${key}_$k", v) }
-            is ArrayList<*> -> this[key] = value.joinToString(",")
-            else -> this[key] = value.toString()
+            is ArrayList<*> -> map[key] = value.joinToString(",")
+            else -> map[key] = value.toString()
         }
     }
 }

--- a/arkenv/src/main/kotlin/com/apurebase/arkenv/feature/PropertyFeature.kt
+++ b/arkenv/src/main/kotlin/com/apurebase/arkenv/feature/PropertyFeature.kt
@@ -1,6 +1,9 @@
 package com.apurebase.arkenv.feature
 
-import com.apurebase.arkenv.*
+import com.apurebase.arkenv.Arkenv
+import com.apurebase.arkenv.putAll
+import com.apurebase.arkenv.split
+import com.apurebase.arkenv.toSnakeCase
 import java.io.File
 import java.io.FileInputStream
 import java.io.InputStream
@@ -14,16 +17,14 @@ import java.util.*
 open class PropertyFeature(
     private val file: String = "application",
     locations: Collection<String> = listOf()
-) : ArkenvFeature, Arkenv("PropertyFeature", ArkenvBuilder(false)) {
+) : ArkenvFeature {
 
     protected open val extensions = listOf("properties")
     private val defaultLocations = locations + listOf("", "config/")
-    private val extraLocations: List<String> by argument("--arkenv-property-location") {
-        defaultValue = ::emptyList
-    }
+    private var extraLocations: List<String> = emptyList()
 
     override fun onLoad(arkenv: Arkenv) {
-        parse(arkenv.argList.toTypedArray())
+        extraLocations = arkenv.getOrNull("--arkenv-property-location")?.split() ?: extraLocations
         val fileNames = if (extensions.any { file.endsWith(".$it") }) listOf(file)
         else extensions.map(::makeFileName)
 

--- a/arkenv/src/main/kotlin/com/apurebase/arkenv/feature/cli/CliFeature.kt
+++ b/arkenv/src/main/kotlin/com/apurebase/arkenv/feature/cli/CliFeature.kt
@@ -16,7 +16,7 @@ class CliFeature : ArkenvFeature {
     override fun onLoad(arkenv: Arkenv) {
         args = arkenv.argList
         args.replaceAll(String::mapRelaxed)
-        loadCliAssignments(arkenv.delegates).let(arkenv::putAll)
+        loadCliAssignments().let(arkenv::putAll)
         val parsed = parseArguments(args)
         args.clear()
         args.addAll(parsed)
@@ -39,19 +39,14 @@ class CliFeature : ArkenvFeature {
     /**
      * Responsible for loading arguments that use the assignment syntax, e.g. key=value
      */
-    private fun loadCliAssignments(delegates: Iterable<ArgumentDelegate<*>>): Map<String, String> {
-        val names = delegates.flatMap { it.argument.names }.map { it.trimStart('-') }
-        return loadArguments(args, names)
-    }
-
-    private fun loadArguments(args: MutableList<String>, names: List<String>): Map<String, String> {
+    private fun loadCliAssignments(): Map<String, String> {
         val map = mutableMapOf<String, String>()
         var i = 0
         while (i < args.size) {
             val value = args[i]
             val split = value.split('=')
             val key = split.first().toSnakeCase()
-            if (split.size == 2 && names.contains(key)) {
+            if (split.size == 2) {
                 args.removeAt(i)
                 map[key] = split.getOrNull(1) ?: ""
             } else if (split.size == 1 && i < args.size - 1) {

--- a/arkenv/src/test/kotlin/com/apurebase/arkenv/LookupTests.kt
+++ b/arkenv/src/test/kotlin/com/apurebase/arkenv/LookupTests.kt
@@ -60,7 +60,7 @@ class LookupTests {
     }
 
     @Nested
-    inner class Nullable {
+    private inner class Nullable {
 
         @Test fun `should resolve unused properties`() {
             val ark = Ark().parse()

--- a/arkenv/src/test/kotlin/com/apurebase/arkenv/RelaxedBindingTests.kt
+++ b/arkenv/src/test/kotlin/com/apurebase/arkenv/RelaxedBindingTests.kt
@@ -15,7 +15,7 @@ internal class RelaxedBindingTests {
     }
 
     @Nested
-    inner class Cli {
+    private inner class Cli {
         private fun verifyCli(key: String) = Ark().parse(key, "5").verify()
 
         @Test fun `UPPERCASE`() {
@@ -32,7 +32,7 @@ internal class RelaxedBindingTests {
     }
 
     @Nested
-    inner class Env {
+    private inner class Env {
         private fun verifyEnv() = Ark().parse().verify()
 
         @Test fun `UPPERCASE`() {
@@ -52,7 +52,7 @@ internal class RelaxedBindingTests {
     }
 
     @Nested
-    inner class Property {
+    private inner class Property {
         private fun verifyProperty(file: String) {
             val ark = Ark(configureArkenv {
                 install(PropertyFeature("$file.properties", listOf("binding")))
@@ -74,7 +74,7 @@ internal class RelaxedBindingTests {
     }
 
     @Nested
-    inner class Assignment {
+    private inner class Assignment {
         private fun verifyAssignment(arg: String) = Ark().parse(arg).verify()
 
         @Test fun `UPPERCASE`() {

--- a/arkenv/src/test/kotlin/com/apurebase/arkenv/feature/ProfileFeatureCustomizationTest.kt
+++ b/arkenv/src/test/kotlin/com/apurebase/arkenv/feature/ProfileFeatureCustomizationTest.kt
@@ -29,7 +29,7 @@ class ProfileFeatureCustomizationTest {
     }
 
     @Nested
-    inner class Prefix {
+    private inner class Prefix {
 
         @Test fun `change via param`() {
             PrefixArk("config").expectThat { isMasterFile() }
@@ -54,7 +54,7 @@ class ProfileFeatureCustomizationTest {
     }
 
     @Nested
-    inner class Location {
+    private inner class Location {
         private val path = "custom/path"
 
         @Test fun `change via param`() {

--- a/arkenv/src/test/kotlin/com/apurebase/arkenv/feature/PropertyFeatureTests.kt
+++ b/arkenv/src/test/kotlin/com/apurebase/arkenv/feature/PropertyFeatureTests.kt
@@ -27,7 +27,7 @@ class PropertyFeatureTests : FileBasedTests {
 
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-    inner class Customization {
+    private inner class Customization {
         private val content = getTestResource("app.properties")
         private val name = "file_based_props.properties"
         private val dir = File("config")

--- a/arkenv/src/test/kotlin/com/apurebase/arkenv/feature/cli/CliFeatureTest.kt
+++ b/arkenv/src/test/kotlin/com/apurebase/arkenv/feature/cli/CliFeatureTest.kt
@@ -1,0 +1,28 @@
+package com.apurebase.arkenv.feature.cli
+
+import com.apurebase.arkenv.get
+import com.apurebase.arkenv.test.Nullable
+import com.apurebase.arkenv.test.expectThat
+import com.apurebase.arkenv.test.parse
+import org.junit.jupiter.api.Test
+import strikt.assertions.isEqualTo
+
+internal class CliFeatureTest {
+
+    @Test fun `resolve undeclared get calls`() {
+        val key = "--undeclared"
+        val expected = "expected"
+        Nullable().parse(key, expected).expectThat {
+            get { get(key) }.isEqualTo(expected)
+        }
+    }
+
+    @Test fun `resolve undeclared assignments`() {
+        val key = "undeclared"
+        val expected = "expected"
+        Nullable().parse("$key=$expected").expectThat {
+            get { get(key) }.isEqualTo(expected)
+        }
+    }
+
+}

--- a/arkenv/src/test/kotlin/com/apurebase/arkenv/feature/cli/MergeTests.kt
+++ b/arkenv/src/test/kotlin/com/apurebase/arkenv/feature/cli/MergeTests.kt
@@ -11,7 +11,7 @@ import strikt.assertions.isTrue
 
 class MergeTests {
 
-    class Arguments : Arkenv() {
+    private class Arguments : Arkenv() {
         val doRun: Boolean by argument("-d", "--do-run")
         val production: Boolean by argument("-p", "--production")
         val something: Boolean by argument("-s", "--something")


### PR DESCRIPTION
Refactor features that extend Arkenv. 

They only use a subset of the features, and it doesn't really make sense to parse twice. 