### PR TITLE
Add postLoad to enable reactive loading

### DIFF
--- a/arkenv/src/main/kotlin/com/apurebase/arkenv/Arkenv.kt
+++ b/arkenv/src/main/kotlin/com/apurebase/arkenv/Arkenv.kt
@@ -23,14 +23,15 @@ abstract class Arkenv(
         defaultValue = { programName }
     }
 
-    internal fun parseArguments(args: Array<out String>) {
-        if (configuration.clearInputBeforeParse) clear()
+    internal fun parseArguments(args: Array<out String>) = with(configuration) {
+        if (clearInputBeforeParse) clear()
         argList.addAll(args)
-        configuration.features.forEach { it.onLoad(this) }
+        features.forEach { it.onLoad(this@Arkenv) }
+        features.forEach { it.postLoad(this@Arkenv) }
         process()
         parse()
-        configuration.features.forEach { it.finally(this) }
-        if (configuration.clearInputAfterParse) clear()
+        features.forEach { it.finally(this@Arkenv) }
+        if (clearInputAfterParse) clear()
     }
 
     /**

--- a/arkenv/src/main/kotlin/com/apurebase/arkenv/feature/ArkenvFeature.kt
+++ b/arkenv/src/main/kotlin/com/apurebase/arkenv/feature/ArkenvFeature.kt
@@ -17,6 +17,13 @@ interface ArkenvFeature {
     }
 
     /**
+     * Executed after all features have been loaded.
+     * Can be used for reactive loading, where one feature is enabled by another one.
+     */
+    fun postLoad(arkenv: Arkenv) {
+    }
+
+    /**
      * Used to assign a value to the [Argument] represented by [delegate].
      */
     fun onParse(arkenv: Arkenv, delegate: ArgumentDelegate<*>): String? {
@@ -26,6 +33,7 @@ interface ArkenvFeature {
     /**
      * Applies configuration to every [argument].
      */
+    @Deprecated("Will be removed in future major version")
     fun configure(argument: Argument<*>) {
     }
 

--- a/arkenv/src/main/kotlin/com/apurebase/arkenv/feature/EnvironmentVariableFeature.kt
+++ b/arkenv/src/main/kotlin/com/apurebase/arkenv/feature/EnvironmentVariableFeature.kt
@@ -30,6 +30,7 @@ class EnvironmentVariableFeature(
         getEnvValue(argument, envSecrets, setEnvPrefix)
     }
 
+    override fun postLoad(arkenv: Arkenv) = onLoad(arkenv)
     /**
      * Loop over all argument names and pick the first one that matches
      */

--- a/arkenv/src/main/kotlin/com/apurebase/arkenv/feature/EnvironmentVariableFeature.kt
+++ b/arkenv/src/main/kotlin/com/apurebase/arkenv/feature/EnvironmentVariableFeature.kt
@@ -19,9 +19,13 @@ class EnvironmentVariableFeature(
     private val dotEnvFilePath: String? = null
 ) : ArkenvFeature {
 
+    private var isLoaded = false
+
     override fun onLoad(arkenv: Arkenv) {
-        loadEnvironmentVariables(arkenv.getOrNull("ARKENV_DOT_ENV_FILE"))
-            ?.let(arkenv::putAll)
+        loadEnvironmentVariables(arkenv.getOrNull("ARKENV_DOT_ENV_FILE"))?.let {
+            arkenv.putAll(it)
+            isLoaded = true
+        }
     }
 
     override fun onParse(arkenv: Arkenv, delegate: ArgumentDelegate<*>): String? = with(delegate) {
@@ -30,7 +34,10 @@ class EnvironmentVariableFeature(
         getEnvValue(argument, envSecrets, setEnvPrefix)
     }
 
-    override fun postLoad(arkenv: Arkenv) = onLoad(arkenv)
+    override fun postLoad(arkenv: Arkenv) {
+        if (!isLoaded) onLoad(arkenv)
+    }
+
     /**
      * Loop over all argument names and pick the first one that matches
      */

--- a/arkenv/src/test/kotlin/com/apurebase/arkenv/feature/EnvFileTests.kt
+++ b/arkenv/src/test/kotlin/com/apurebase/arkenv/feature/EnvFileTests.kt
@@ -3,6 +3,7 @@ package com.apurebase.arkenv.feature
 import com.apurebase.arkenv.Arkenv
 import com.apurebase.arkenv.argument
 import com.apurebase.arkenv.configureArkenv
+import com.apurebase.arkenv.test.dotEnvPath
 import com.apurebase.arkenv.test.expectThat
 import com.apurebase.arkenv.test.getTestResourcePath
 import com.apurebase.arkenv.test.parse
@@ -31,7 +32,7 @@ class EnvFileTests {
     }
 
     @Test fun `should load values from dot env file`() {
-        EnvFileArk(path).parse().expectThat { verify() }
+        EnvFileArk(dotEnvPath).parse().expectThat { verify() }
     }
 
     @Test fun `dot env file can be specified via argument`() {
@@ -58,6 +59,5 @@ class EnvFileTests {
         get { connectionString }.isEqualTo("localhost")
     }
 
-    private val path = getTestResourcePath(".env")
     private val altPath = getTestResourcePath(".env-alt")
 }

--- a/arkenv/src/test/kotlin/com/apurebase/arkenv/feature/PlaceholderTests.kt
+++ b/arkenv/src/test/kotlin/com/apurebase/arkenv/feature/PlaceholderTests.kt
@@ -19,8 +19,8 @@ class PlaceholderTests {
     }
 
     @Test fun `can refer to previously defined arg in properties`() {
-        val ark = Ark { install(PropertyFeature("placeholders.properties")) }
-        ark.parse()
+        Ark { install(PropertyFeature("placeholders.properties")) }
+            .parse()
             .verify()
     }
 
@@ -82,13 +82,16 @@ class PlaceholderTests {
         val testValue = "this_is_expected"
         val expected = "$testValue is not declared"
 
-        val ark = Ark {
-            install(EnvironmentVariableFeature(dotEnvFilePath = getTestResourcePath(".env")))
-        }
-        ark.parse(appNameArg, appName, appDescArg, "\${mysql_password} is not declared")
+        Ark { install(EnvironmentVariableFeature(dotEnvFilePath = getTestResourcePath(".env"))) }
+            .parse(appNameArg, appName, appDescArg, "\${mysql_password} is not declared")
             .expectThat {
                 get { description }.isEqualTo(expected)
             }
+    }
+
+    @Test fun `refer to env from profile`() {
+        Ark().parse("--arkenv-profile", "placeholder")
+            .verify()
     }
 
     @Test fun `should throw when placeholder is not found`() {

--- a/arkenv/src/test/kotlin/com/apurebase/arkenv/feature/PlaceholderTests.kt
+++ b/arkenv/src/test/kotlin/com/apurebase/arkenv/feature/PlaceholderTests.kt
@@ -1,14 +1,12 @@
 package com.apurebase.arkenv.feature
 
 import com.apurebase.arkenv.*
-import com.apurebase.arkenv.test.MockSystem
-import com.apurebase.arkenv.test.expectThat
-import com.apurebase.arkenv.test.getTestResourcePath
-import com.apurebase.arkenv.test.parse
+import com.apurebase.arkenv.test.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertThrows
 import strikt.assertions.isEqualTo
+import java.io.File
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class PlaceholderTests {
@@ -82,7 +80,7 @@ class PlaceholderTests {
         val testValue = "this_is_expected"
         val expected = "$testValue is not declared"
 
-        Ark { install(EnvironmentVariableFeature(dotEnvFilePath = getTestResourcePath(".env"))) }
+        Ark { install(EnvironmentVariableFeature(dotEnvFilePath = dotEnvPath)) }
             .parse(appNameArg, appName, appDescArg, "\${mysql_password} is not declared")
             .expectThat {
                 get { description }.isEqualTo(expected)
@@ -90,6 +88,7 @@ class PlaceholderTests {
     }
 
     @Test fun `refer to env from profile`() {
+
         Ark().parse("--arkenv-profile", "placeholder")
             .verify()
     }

--- a/arkenv/src/test/kotlin/com/apurebase/arkenv/feature/ProfileFeatureTest.kt
+++ b/arkenv/src/test/kotlin/com/apurebase/arkenv/feature/ProfileFeatureTest.kt
@@ -3,15 +3,11 @@ package com.apurebase.arkenv.feature
 import com.apurebase.arkenv.Arkenv
 import com.apurebase.arkenv.argument
 import com.apurebase.arkenv.configureArkenv
-import com.apurebase.arkenv.test.DEPRECATED
 import com.apurebase.arkenv.test.MockSystem
 import com.apurebase.arkenv.test.expectThat
 import com.apurebase.arkenv.test.parse
-import org.amshove.kluent.shouldNotBeNull
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.junit.jupiter.api.assertThrows
 import strikt.api.Assertion
 import strikt.assertions.isEqualTo
 

--- a/arkenv/src/test/kotlin/com/apurebase/arkenv/test/TestUtil.kt
+++ b/arkenv/src/test/kotlin/com/apurebase/arkenv/test/TestUtil.kt
@@ -15,4 +15,4 @@ fun <T : Arkenv> T.parse(vararg arguments: String) = apply { parseArguments(argu
 
 fun getTestResource(name: String) = MockSystem::class.java.classLoader.getResource(name)!!.readText()
 
-const val DEPRECATED = "Property files are no longer required, can be null."
+val dotEnvPath = getTestResourcePath(".env")

--- a/arkenv/src/test/resources/.env
+++ b/arkenv/src/test/resources/.env
@@ -6,3 +6,5 @@ DATABASE_PORT=5050
 # Everywhere
 
 CONNECTION_STRING=localhost:${DATABASE_PORT};database=testdb;user=testuser;
+
+APP_NAME=MyApp

--- a/arkenv/src/test/resources/application-placeholder.properties
+++ b/arkenv/src/test/resources/application-placeholder.properties
@@ -1,0 +1,2 @@
+APP_DESCRIPTION     = ${APP_NAME} is a Arkenv application
+ARKENV_DOT_ENV_FILE = src\\test\\resources\\.env

--- a/arkenv/src/test/resources/application-placeholder.properties
+++ b/arkenv/src/test/resources/application-placeholder.properties
@@ -1,2 +1,2 @@
 APP_DESCRIPTION     = ${APP_NAME} is a Arkenv application
-ARKENV_DOT_ENV_FILE = src\\test\\resources\\.env
+ARKENV_DOT_ENV_FILE = src/test/resources/.env

--- a/docs/features/features.md
+++ b/docs/features/features.md
@@ -49,6 +49,7 @@ interface.
 
 It has 3 overridable methods:
 * `onLoad` is used to read data from a source and store it for parsing. 
+* `postLoad` is used to react to configuration after all features have been loaded.
 * `onParse` is used on each argument property when parsing to obtain a value.
 * `finally` can be used for clean up. 
 

--- a/docs/features/features.md
+++ b/docs/features/features.md
@@ -47,7 +47,7 @@ This means that by default command line arguments have the highest order and wil
 To create a new feature from scratch, simply implement the `ArkenvFeature`
 interface. 
 
-It has 3 overridable methods:
+It has 4 overridable methods:
 * `onLoad` is used to read data from a source and store it for parsing. 
 * `postLoad` is used to react to configuration after all features have been loaded.
 * `onParse` is used on each argument property when parsing to obtain a value.


### PR DESCRIPTION
Closes #22 

In order to enable reactive loading, where a feature is enabled by another one, the method `postLoad` has been added to `ArkenvFeature`.

This allows to specify a .env file from a profile.