### PR TITLE
Common prefix support

### DIFF
--- a/arkenv/src/main/kotlin/com/apurebase/arkenv/Arkenv.kt
+++ b/arkenv/src/main/kotlin/com/apurebase/arkenv/Arkenv.kt
@@ -67,9 +67,7 @@ abstract class Arkenv(
 
     private fun process() {
         configuration.processorFeatures.forEach { it.arkenv = this }
-        keyValue.replaceAll { key, value ->
-            processValue(key, value)
-        }
+        keyValue.replaceAll(::processValue)
     }
 
     private fun processValue(key: String, value: String): String = configuration

--- a/arkenv/src/main/kotlin/com/apurebase/arkenv/ArkenvBuilder.kt
+++ b/arkenv/src/main/kotlin/com/apurebase/arkenv/ArkenvBuilder.kt
@@ -10,6 +10,11 @@ import com.apurebase.arkenv.feature.cli.CliFeature
 class ArkenvBuilder(installAdvancedFeatures: Boolean = true) {
 
     /**
+     * A common prefix that is applied to all argument names when not blank.
+     */
+    var commonPrefix = ""
+
+    /**
      * Whether data should be cleared before parsing.
      */
     var clearInputBeforeParse = true

--- a/arkenv/src/main/kotlin/com/apurebase/arkenv/ArkenvBuilder.kt
+++ b/arkenv/src/main/kotlin/com/apurebase/arkenv/ArkenvBuilder.kt
@@ -10,9 +10,9 @@ import com.apurebase.arkenv.feature.cli.CliFeature
 class ArkenvBuilder(installAdvancedFeatures: Boolean = true) {
 
     /**
-     * A common prefix that is applied to all argument names when not blank.
+     * A common prefix that is applied to all argument names.
      */
-    var commonPrefix = ""
+    var prefix: String? = null
 
     /**
      * Whether data should be cleared before parsing.

--- a/arkenv/src/main/kotlin/com/apurebase/arkenv/ArkenvDelegateLoader.kt
+++ b/arkenv/src/main/kotlin/com/apurebase/arkenv/ArkenvDelegateLoader.kt
@@ -16,7 +16,14 @@ class ArkenvDelegateLoader<T : Any>(
     private fun getNames(names: List<String>, propName: String) =
         names.ifEmpty { listOf("--${propName.toSnakeCase()}") }
             .map {
-                if (!it.startsWith("-")) "--$it".mapRelaxed()
-                else it.mapRelaxed()
+                (if (!it.startsWith("-")) "--$it" else it)
+                    .prefix(arkenv.configuration.commonPrefix)
+                    .mapRelaxed()
             }
+
+    private fun String.prefix(value: String): String = when {
+        value.isBlank() -> this
+        isAdvancedName() -> "--$value-${substring(2)}"
+        else -> "-$value-${substring(1)}"
+    }
 }

--- a/arkenv/src/main/kotlin/com/apurebase/arkenv/ArkenvDelegateLoader.kt
+++ b/arkenv/src/main/kotlin/com/apurebase/arkenv/ArkenvDelegateLoader.kt
@@ -13,13 +13,16 @@ class ArkenvDelegateLoader<T : Any>(
             .also { arkenv.delegates.add(it) }
     }
 
-    private fun getNames(names: List<String>, propName: String) =
-        names.ifEmpty { listOf("--${propName.toSnakeCase()}") }
-            .map {
-                (if (!it.startsWith("-")) "--$it" else it)
-                    .prefix(arkenv.configuration.commonPrefix)
-                    .mapRelaxed()
-            }
+    private fun getNames(names: List<String>, propName: String) = names
+        .ifEmpty { listOf(propName.toSnakeCase()) }
+        .map {
+            it.ensureStartsWithDash()
+                .prefix(arkenv.configuration.prefix ?: "")
+                .mapRelaxed()
+        }
+
+    private fun String.ensureStartsWithDash() =
+        if (!startsWith("-")) "--$this" else this
 
     private fun String.prefix(value: String): String = when {
         value.isBlank() -> this

--- a/arkenv/src/test/kotlin/com/apurebase/arkenv/GeneralTest.kt
+++ b/arkenv/src/test/kotlin/com/apurebase/arkenv/GeneralTest.kt
@@ -152,7 +152,7 @@ class GeneralTest {
                 get { bool }.isTrue()
             }
     }
-    
+
     @Test fun `should pass when delegates are empty`() {
         val ark = object : Arkenv() {}
         ark.parse("-empty")
@@ -172,5 +172,19 @@ class GeneralTest {
 
         ark.parse("--newVersion", "2")
             .expectThat { get { version }.isEqualTo(2) }
+    }
+
+    @Test fun `common prefix`() {
+        val expectedPort = 90
+        val prefix = "database"
+        val ark = object : Arkenv(configuration = configureArkenv {
+            commonPrefix = prefix
+        }) {
+            val port: Int by argument()
+        }
+        ark.parse("--$prefix-port", expectedPort.toString())
+            .expectThat {
+                get { port }.isEqualTo(expectedPort)
+            }
     }
 }

--- a/arkenv/src/test/kotlin/com/apurebase/arkenv/GeneralTest.kt
+++ b/arkenv/src/test/kotlin/com/apurebase/arkenv/GeneralTest.kt
@@ -178,7 +178,7 @@ class GeneralTest {
         val expectedPort = 90
         val prefix = "database"
         val ark = object : Arkenv(configuration = configureArkenv {
-            commonPrefix = prefix
+            this.prefix = prefix
         }) {
             val port: Int by argument()
         }

--- a/arkenv/src/test/kotlin/com/apurebase/arkenv/ModuleTests.kt
+++ b/arkenv/src/test/kotlin/com/apurebase/arkenv/ModuleTests.kt
@@ -30,4 +30,23 @@ internal class ModuleTests {
                 get { database.port }.isEqualTo(port)
             }
     }
+
+    @Test fun `common prefix config`() {
+        val expectedPort = 90
+        val prefix = "database"
+        val sub = object : Arkenv("Test", configureArkenv {
+            commonPrefix = prefix
+        }) {
+            val port: Int by argument()
+        }
+
+        val ark = object : Arkenv() {
+            val database = module(sub)
+        }
+
+        ark.parse("--$prefix-port", expectedPort.toString())
+            .expectThat {
+                get { database.port }.isEqualTo(expectedPort)
+            }
+    }
 }

--- a/arkenv/src/test/kotlin/com/apurebase/arkenv/ModuleTests.kt
+++ b/arkenv/src/test/kotlin/com/apurebase/arkenv/ModuleTests.kt
@@ -35,7 +35,7 @@ internal class ModuleTests {
         val expectedPort = 90
         val prefix = "database"
         val sub = object : Arkenv("Test", configureArkenv {
-            commonPrefix = prefix
+            this.prefix = prefix
         }) {
             val port: Int by argument()
         }


### PR DESCRIPTION
Closes #28 

Support for a common prefix defined at the Arkenv-level.

```kotlin
val ark = object : Arkenv(configuration = configureArkenv {
    commonPrefix = "prefix"
})
```