### PR TITLE
Update and restrict dependencies.

### DIFF
--- a/arkenv-yaml/build.gradle
+++ b/arkenv-yaml/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
-    compile project(':arkenv')
-    compile "org.yaml:snakeyaml:$snakeyaml_version"
+    implementation project(':arkenv')
+    implementation "org.yaml:snakeyaml:$snakeyaml_version"
 
     testCompile project(':arkenv').sourceSets.test.output
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id "org.jetbrains.kotlin.jvm" version "1.4.0"
-    id "com.github.ben-manes.versions" version "0.33.0"
+    id "org.jetbrains.kotlin.jvm" version "1.4.21"
+    id "com.github.ben-manes.versions" version "0.36.0"
     id "com.jfrog.bintray" version "1.8.5"
     id "io.gitlab.arturbosch.detekt" version "1.0.1"
     id "java"
@@ -26,7 +26,7 @@ allprojects {
 
     ext {
         junit_version = '5.7.0'
-        snakeyaml_version = '1.26'
+        snakeyaml_version = '1.27'
     }
 
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
@@ -36,12 +36,12 @@ allprojects {
     }
 
     dependencies {
-        compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+        implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
         testCompile "org.yaml:snakeyaml:$snakeyaml_version"
         testCompile "org.jmockit:jmockit:1.49"
-        testCompile group: 'org.amshove.kluent', name: 'kluent', version: '1.61'
+        testCompile group: 'org.amshove.kluent', name: 'kluent', version: '1.65'
         testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: junit_version
-        testCompile "io.strikt:strikt-core:0.28.0"
+        testCompile "io.strikt:strikt-core:0.28.1"
         testRuntime "org.junit.jupiter:junit-jupiter-engine:$junit_version"
     }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Use `implementation` rather than `compile`.
Up dependencies.